### PR TITLE
Fix first day posts

### DIFF
--- a/src/daily.rs
+++ b/src/daily.rs
@@ -25,6 +25,10 @@ pub async fn daily_posts(aoc_data: Arc<Mutex<AOCData>>, ctx: Context) {
         log::info!("Waiting for {mins_until_hour} mins until next hour...");
         tokio::time::sleep(Duration::from_secs(60 * mins_until_hour)).await;
 
+        // Get the current time after waiting
+        let time = Utc::now().with_timezone(&tz);
+        let year = time.year() as usize;
+
         // Is it not december yet?
         if time.month() != 12 {
             log::info!("Not December, skipping daily posts");
@@ -37,9 +41,6 @@ pub async fn daily_posts(aoc_data: Arc<Mutex<AOCData>>, ctx: Context) {
             continue;
         }
 
-        // Get the current time after waiting
-        let time = Utc::now().with_timezone(&tz);
-        let year = time.year() as usize;
         let day = time.day() as usize;
         let hour = time.hour() as usize;
         log::info!(


### PR DESCRIPTION
Previously, the bot would check if it was December after waiting 1 hour, but using the timestamp from before waiting, so it would always miss the post on day 1 if set to 0:00 EST. I've just moved the check below fetching the updated time, so this should now be resolved.